### PR TITLE
replace checkpoing model name

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -26,7 +26,7 @@ class Model():
         self.labels = ['neutral', 'happy', 'sad', 'surprise', 'fear', 'disgust', 'anger', 'contempt']
 
         self.model = DAN(num_head=4, num_class=8, pretrained=False)
-        checkpoint = torch.load('./checkpoints/affecnet8_epoch6_acc0.6326.pth',
+        checkpoint = torch.load('./checkpoints/affecnet8_epoch5_acc0.6209.pth',
             map_location=self.device)
         self.model.load_state_dict(checkpoint['model_state_dict'],strict=True)
         self.model.to(self.device)


### PR DESCRIPTION
affecnet8_epoch6_acc0.6326.pth does not exist in Baidu or in Google, but affecnet8_epoch5_acc0.6209 does